### PR TITLE
Compute gradient of the total cost

### DIFF
--- a/traj_opt/test/trajectory_optimizer_test.cc
+++ b/traj_opt/test/trajectory_optimizer_test.cc
@@ -27,7 +27,7 @@ using multibody::Parser;
 using test::LimitMalloc;
 
 GTEST_TEST(TrajectoryOptimizerTest, CalcGradient) {
-  // Set up an optimization problem 
+  // Set up an optimization problem
   const int num_steps = 5;
   const double dt = 1e-3;
 
@@ -35,11 +35,11 @@ GTEST_TEST(TrajectoryOptimizerTest, CalcGradient) {
   opt_prob.num_steps = num_steps;
   opt_prob.q_init = Vector1d(0.1);
   opt_prob.v_init = Vector1d(0.0);
-  opt_prob.Qq = 0.1 * MatrixXd::Identity(1,1);
-  opt_prob.Qv = 0.2 * MatrixXd::Identity(1,1);
-  opt_prob.Qf_q = 0.3 * MatrixXd::Identity(1,1);
-  opt_prob.Qf_v = 0.4 * MatrixXd::Identity(1,1);
-  opt_prob.R = 0.5 * MatrixXd::Identity(1,1);
+  opt_prob.Qq = 0.1 * MatrixXd::Identity(1, 1);
+  opt_prob.Qv = 0.2 * MatrixXd::Identity(1, 1);
+  opt_prob.Qf_q = 0.3 * MatrixXd::Identity(1, 1);
+  opt_prob.Qf_v = 0.4 * MatrixXd::Identity(1, 1);
+  opt_prob.R = 0.5 * MatrixXd::Identity(1, 1);
   opt_prob.q_nom = Vector1d(0.1);
   opt_prob.v_nom = Vector1d(-0.1);
 
@@ -51,23 +51,23 @@ GTEST_TEST(TrajectoryOptimizerTest, CalcGradient) {
   plant.set_discrete_contact_solver(DiscreteContactSolver::kSap);
   plant.Finalize();
 
-  // Create an optimizer 
+  // Create an optimizer
   TrajectoryOptimizerWorkspace workspace(plant);
   TrajectoryOptimizer optimizer(&plant, opt_prob);
 
   // Make some fake data
-  std::vector<VectorXd> q(num_steps+1);
+  std::vector<VectorXd> q(num_steps + 1);
   q[0] = opt_prob.q_init;
   for (int t = 1; t <= num_steps; ++t) {
-    q[t] = q[t-1] + 0.1*dt*MatrixXd::Identity(1,1);
+    q[t] = q[t - 1] + 0.1 * dt * MatrixXd::Identity(1, 1);
   }
 
   // Compute the ("ground truth") gradient with finite differences
-  VectorXd g_gt(plant.num_positions()*(num_steps+1));
+  VectorXd g_gt(plant.num_positions() * (num_steps + 1));
   optimizer.CalcGradientFiniteDiff(q, &workspace, &g_gt);
 
   // Compute the gradient with our method
-  VectorXd g(plant.num_positions()*(num_steps+1));
+  VectorXd g(plant.num_positions() * (num_steps + 1));
   GradientData grad_data(num_steps, 1, 1);
   std::vector<VectorXd> v(num_steps + 1);
   optimizer.CalcV(q, &v);
@@ -76,10 +76,9 @@ GTEST_TEST(TrajectoryOptimizerTest, CalcGradient) {
 
   // Compare the two (we don't quite get the theoretical eps^(2/3) accuracy)
   const double kTolerance = pow(std::numeric_limits<double>::epsilon(), 0.5);
-  EXPECT_TRUE(CompareMatrices(g, g_gt, kTolerance, MatrixCompareType::relative));
-
+  EXPECT_TRUE(
+      CompareMatrices(g, g_gt, kTolerance, MatrixCompareType::relative));
 }
-
 
 GTEST_TEST(TrajectoryOptimizerTest, PendulumDtauDq) {
   const int num_steps = 5;
@@ -196,8 +195,9 @@ GTEST_TEST(TrajectoryOptimizerTest, CalcCost) {
   v.push_back(Vector2d(-0.1, 0.0));
 
   // Compute the cost and compare with the true value
+  TrajectoryOptimizerWorkspace workspace(plant);
   TrajectoryOptimizer optimizer(&plant, opt_prob);
-  double L = optimizer.CalcCost(q, v, tau);
+  double L = optimizer.CalcCost(q, v, tau, &workspace);
   double L_gt =
       num_steps * dt * (2 * 0.1 + 2 * 0.2 + 2 * 0.5) + 2 * 0.3 + 2 * 0.4;
 

--- a/traj_opt/test/trajectory_optimizer_test.cc
+++ b/traj_opt/test/trajectory_optimizer_test.cc
@@ -33,15 +33,15 @@ GTEST_TEST(TrajectoryOptimizerTest, CalcGradient) {
 
   ProblemDefinition opt_prob;
   opt_prob.num_steps = num_steps;
-  opt_prob.q_init = Vector1d(0.0);
+  opt_prob.q_init = Vector1d(0.1);
   opt_prob.v_init = Vector1d(0.0);
   opt_prob.Qq = 0.1 * MatrixXd::Identity(1,1);
   opt_prob.Qv = 0.2 * MatrixXd::Identity(1,1);
   opt_prob.Qf_q = 0.3 * MatrixXd::Identity(1,1);
   opt_prob.Qf_v = 0.4 * MatrixXd::Identity(1,1);
   opt_prob.R = 0.5 * MatrixXd::Identity(1,1);
-  opt_prob.q_nom = Vector1d(0.0);
-  opt_prob.v_nom = Vector1d(0.1);
+  opt_prob.q_nom = Vector1d(0.1);
+  opt_prob.v_nom = Vector1d(-0.1);
 
   // Create a pendulum model
   MultibodyPlant<double> plant(dt);
@@ -59,7 +59,7 @@ GTEST_TEST(TrajectoryOptimizerTest, CalcGradient) {
   std::vector<VectorXd> q(num_steps+1);
   q[0] = opt_prob.q_init;
   for (int t = 1; t <= num_steps; ++t) {
-    q[t] = q[t-1] + 0.0*dt*MatrixXd::Identity(1,1);
+    q[t] = q[t-1] + 0.1*dt*MatrixXd::Identity(1,1);
   }
 
   // Compute the ("ground truth") gradient with finite differences
@@ -75,21 +75,12 @@ GTEST_TEST(TrajectoryOptimizerTest, CalcGradient) {
 
   optimizer.CalcGradient(q, grad_data, &workspace, &g);
 
-
   // Compare
   for (int t=0; t <= num_steps; ++t) {
     std::cout << "t = " << t << std::endl;
     std::cout << "true: " << g_gt[t] << std::endl;
     std::cout << "ours: " << g[t] << std::endl;
   }
-
-  // DEBUG
-  std::vector<VectorXd> tau(num_steps);
-  optimizer.CalcTau(q, v, &workspace, &tau);
-  for (int t=0; t <= num_steps; ++t) {
-    std::cout << tau[t] << std::endl;
-  }
-
 
 }
 

--- a/traj_opt/test/trajectory_optimizer_test.cc
+++ b/traj_opt/test/trajectory_optimizer_test.cc
@@ -72,15 +72,11 @@ GTEST_TEST(TrajectoryOptimizerTest, CalcGradient) {
   std::vector<VectorXd> v(num_steps + 1);
   optimizer.CalcV(q, &v);
   optimizer.CalcInverseDynamicsPartials(q, v, &workspace, &grad_data);
-
   optimizer.CalcGradient(q, grad_data, &workspace, &g);
 
-  // Compare
-  for (int t=0; t <= num_steps; ++t) {
-    std::cout << "t = " << t << std::endl;
-    std::cout << "true: " << g_gt[t] << std::endl;
-    std::cout << "ours: " << g[t] << std::endl;
-  }
+  // Compare the two (we don't quite get the theoretical eps^(2/3) accuracy)
+  const double kTolerance = pow(std::numeric_limits<double>::epsilon(), 0.5);
+  EXPECT_TRUE(CompareMatrices(g, g_gt, kTolerance, MatrixCompareType::relative));
 
 }
 

--- a/traj_opt/trajectory_optimizer.cc
+++ b/traj_opt/trajectory_optimizer.cc
@@ -62,6 +62,8 @@ double TrajectoryOptimizer::CalcCost(
 double TrajectoryOptimizer::CalcCost(
     const std::vector<VectorXd>& q,
     TrajectoryOptimizerWorkspace* workspace) const {
+  // These are expensive heap allocations: prefer versions of CalcCost that
+  // use precomputed v and tau whenever possible.
   std::vector<VectorXd> v(num_steps() + 1);
   std::vector<VectorXd> tau(num_steps());
 
@@ -254,6 +256,7 @@ void TrajectoryOptimizer::CalcGradientFiniteDiff(
     const std::vector<VectorXd>& q, TrajectoryOptimizerWorkspace* workspace,
     EigenPtr<VectorXd> g) const {
   // Allocate perturbed versions of q
+  // TODO(vincekurtz): consider allocating in workspace
   std::vector<VectorXd> q_plus(q);
   std::vector<VectorXd> q_minus(q);
 

--- a/traj_opt/trajectory_optimizer.h
+++ b/traj_opt/trajectory_optimizer.h
@@ -71,20 +71,23 @@ class TrajectoryOptimizer {
    * @param q sequence of generalized positions
    * @param v sequence of generalized velocities (consistent with q)
    * @param tau sequence of generalized forces (consistent with q and v)
+   * @param workspace scratch space for intermediate computations
    * @return double the total cost
    */
   double CalcCost(const std::vector<VectorXd>& q,
                   const std::vector<VectorXd>& v,
-                  const std::vector<VectorXd>& tau) const;
+                  const std::vector<VectorXd>& tau,
+                  TrajectoryOptimizerWorkspace* workspace) const;
 
   /**
-   * Convienience function which computes the total cost as a function of q directly, 
-   * and includes the intermediate computation of v(q) and tau(q).
-   * 
+   * Convienience function which computes the total cost as a function of q
+   * directly, and includes the intermediate computation of v(q) and tau(q).
+   *
    * @param q sequence of generalized positions
    * @return double the total cost
    */
-  double CalcCost(const std::vector<VectorXd>& q, TrajectoryOptimizerWorkspace* workspace) const;
+  double CalcCost(const std::vector<VectorXd>& q,
+                  TrajectoryOptimizerWorkspace* workspace) const;
 
   /**
    * Compute a sequence of generalized velocities v from a sequence of
@@ -140,13 +143,17 @@ class TrajectoryOptimizer {
    * @param g a single VectorXd containing the partials of L w.r.t. each
    *          decision variable (q_t[i]).
    */
-  void CalcGradient(const std::vector<VectorXd>& q, const GradientData& grad_data,
+  void CalcGradient(const std::vector<VectorXd>& q,
+                    const GradientData& grad_data,
                     TrajectoryOptimizerWorkspace* workspace,
                     EigenPtr<VectorXd> g) const;
 
   /**
    * Compute the gradient of the unconstrained cost L(q) using finite
    * differences.
+   *
+   * Uses central differences, so with a perturbation on the order of eps^(1/3),
+   * we expect errors on the order of eps^(2/3).
    *
    * For testing purposes only.
    *

--- a/traj_opt/trajectory_optimizer.h
+++ b/traj_opt/trajectory_optimizer.h
@@ -73,6 +73,8 @@ class TrajectoryOptimizer {
    * @param tau sequence of generalized forces (consistent with q and v)
    * @param workspace scratch space for intermediate computations
    * @return double the total cost
+   *
+   * TODO(vincekurtz): take a TrajectoryOptimizerState instead of q, v, tau
    */
   double CalcCost(const std::vector<VectorXd>& q,
                   const std::vector<VectorXd>& v,

--- a/traj_opt/trajectory_optimizer.h
+++ b/traj_opt/trajectory_optimizer.h
@@ -134,17 +134,29 @@ class TrajectoryOptimizer {
                std::vector<VectorXd>* tau) const;
 
   /**
+   * Compute the gradient of the unconstrained cost L(q).
+   *
+   * @param q vector of generalized positions at each timestep
+   * @param g a single VectorXd containing the partials of L w.r.t. each
+   *          decision variable (q_t[i]).
+   */
+  void CalcGradient(const std::vector<VectorXd>& q, const GradientData& grad_data,
+                    TrajectoryOptimizerWorkspace* workspace,
+                    EigenPtr<VectorXd> g) const;
+
+  /**
    * Compute the gradient of the unconstrained cost L(q) using finite
    * differences.
    *
    * For testing purposes only.
    *
-   * TODO(vincekurtz): refactor so this takes the same structure as CalcGradient
    * @param q vector of generalized positions at each timestep
    * @param g a single VectorXd containing the partials of L w.r.t. each
    *          decision variable (q_t[i]).
    */
-  void CalcGradientFiniteDiff(const std::vector<VectorXd>& q, TrajectoryOptimizerWorkspace* workspace, EigenPtr<VectorXd> g) const;
+  void CalcGradientFiniteDiff(const std::vector<VectorXd>& q,
+                              TrajectoryOptimizerWorkspace* workspace,
+                              EigenPtr<VectorXd> g) const;
 
   /**
    * Compute partial derivatives of the inverse dynamics

--- a/traj_opt/trajectory_optimizer.h
+++ b/traj_opt/trajectory_optimizer.h
@@ -77,6 +77,15 @@ class TrajectoryOptimizer {
                   const std::vector<VectorXd>& tau) const;
 
   /**
+   * Convienience function which computes the total cost as a function of q directly, 
+   * and includes the intermediate computation of v(q) and tau(q).
+   * 
+   * @param q sequence of generalized positions
+   * @return double the total cost
+   */
+  double CalcCost(const std::vector<VectorXd>& q) const;
+
+  /**
    * Compute a sequence of generalized velocities v from a sequence of
    * generalized positions, where
    *
@@ -123,6 +132,19 @@ class TrajectoryOptimizer {
   void CalcTau(const std::vector<VectorXd>& q, const std::vector<VectorXd>& v,
                VectorXd* a, MultibodyForces<double>* f_ext,
                std::vector<VectorXd>* tau) const;
+
+  /**
+   * Compute the gradient of the unconstrained cost L(q) using finite
+   * differences.
+   *
+   * For testing purposes only.
+   *
+   * TODO(vincekurtz): refactor so this takes the same structure as CalcGradient
+   * @param q vector of generalized positions at each timestep
+   * @param g a single VectorXd containing the partials of L w.r.t. each
+   *          decision variable (q_t[i]).
+   */
+  void CalcGradientFiniteDiff(const std::vector<VectorXd>& q, EigenPtr<VectorXd> g) const;
 
  private:
   // A model of the system that we are trying to find an optimal trajectory for.


### PR DESCRIPTION
Computes the gradient `g` of the total cost with respect to `q` (our only decision variables). 

Adding a `TrajectoryOptimizerState` (future PR) should clean up the logic considerably.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vincekurtz/drake/19)
<!-- Reviewable:end -->
