### PR TITLE
Minor fixes for easier example setup

### DIFF
--- a/traj_opt/examples/example_base.cc
+++ b/traj_opt/examples/example_base.cc
@@ -19,7 +19,7 @@ void TrajOptExample::SolveTrajectoryOptimization(
   auto [plant, scene_graph] = AddMultibodyPlant(config, &builder);
   CreatePlantModel(&plant);
   plant.Finalize();
-  const int nv = plant.num_positions();
+  const int nv = plant.num_velocities();
 
   auto diagram = builder.Build();
 
@@ -46,7 +46,6 @@ void TrajOptExample::SolveTrajectoryOptimization(
   // Solve the optimzation problem
   TrajectoryOptimizer<double> optimizer(diagram.get(), &plant, opt_prob,
                                         solver_params);
-
   TrajectoryOptimizerSolution<double> solution;
   TrajectoryOptimizerStats<double> stats;
   ConvergenceReason reason;

--- a/traj_opt/examples/yaml_config.h
+++ b/traj_opt/examples/yaml_config.h
@@ -98,7 +98,7 @@ struct TrajOptExampleParams {
   ConvergenceCriteriaTolerances tolerances;
 
   // Linesearch method, "backtracking" or "armijo"
-  std::string linesearch;
+  std::string linesearch{"armijo"};
 
   // Optimization method, "linesearch" or "trust_region"
   std::string method;

--- a/traj_opt/scripts/plot_convergence_data.py
+++ b/traj_opt/scripts/plot_convergence_data.py
@@ -18,8 +18,7 @@ import sys
 
 # Command-line flags determine which example (pendulum, acrobot, spinner) we're
 # dealing with. 
-possible_example_names = ["pendulum", "acrobot", "spinner", "2dof_spinner", "wall_ball", "frictionless_spinner"]
-if (len(sys.argv) != 2) or (sys.argv[1] not in possible_example_names):
+if (len(sys.argv) != 2):
     print(f"Usage: {sys.argv[0]} {possible_example_names}")
     print("\nThe corresponding example must be run first (e.g. 'bazel run traj_opt/examples:pendulum`), with 'save_solver_stats_csv=true'")
     sys.exit(1)


### PR DESCRIPTION
- Fixes a small bug related to quaternion DoFs
- Sets a default linesearch method, so we don't need to specify it in YAML (we're using trust region anyway)
- Doesn't restrict convergence plots to a pre-specified list of examples

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vincekurtz/drake/42)
<!-- Reviewable:end -->
