### PR TITLE
Add instrumentation for profiling

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -50,6 +50,7 @@ drake_cc_package_library(
         ":nice_type_name",
         ":pointer_cast",
         ":polynomial",
+        ":profiler",
         ":random",
         ":reset_after_move",
         ":reset_on_copy",
@@ -194,6 +195,16 @@ drake_cc_library(
         ":default_scalars",
         ":essential",
         "//common/symbolic:expression",
+    ],
+)
+
+drake_cc_library(
+    name = "profiler",
+    srcs = ["profiler.cc"],
+    hdrs = ["profiler.h"],
+    deps = [
+        ":scope_exit",
+        ":type_safe_index",
     ],
 )
 
@@ -1071,6 +1082,12 @@ drake_cc_googletest(
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:random_polynomial_matrix",
     ],
+)
+
+drake_cc_googletest(
+    name = "profiler_test",
+    copts = ["-DENABLE_TIMERS"],
+    deps = [":profiler"],    
 )
 
 drake_cc_googletest(

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -1087,7 +1087,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "profiler_test",
     copts = ["-DENABLE_TIMERS"],
-    deps = [":profiler"],    
+    deps = [":profiler"],
 )
 
 drake_cc_googletest(

--- a/common/profiler.cc
+++ b/common/profiler.cc
@@ -22,8 +22,8 @@ void Timer::start() { start_ = std::chrono::high_resolution_clock::now(); }
 
 namespace {
 
-using drake::common::TimerIndex;
 using drake::common::LapTimer;
+using drake::common::TimerIndex;
 
 /**  Class for storing sets of timers for profiling. This is a singleton class
  and _not_ threadsafe.  */
@@ -56,15 +56,13 @@ class Profiler {
     return index;
   }
 
-  void PopTimer() {
-    timers_stack_.pop();
-  }
+  void PopTimer() { timers_stack_.pop(); }
 
   void UpdateStack(double total_time) {
     double& self_time = self_wallclock_[timers_stack_.top()];
     self_time += total_time;
     std::stack<TimerIndex> parent_timers(timers_stack_);  // copy.
-    parent_timers.pop();  // remove self.
+    parent_timers.pop();                                  // remove self.
     if (!parent_timers.empty()) {
       self_wallclock_[parent_timers.top()] -= total_time;
     }
@@ -84,7 +82,7 @@ class Profiler {
        timer.
    @param  i  The identifier for the timer. Only checked in debug mode.
    @tparam Units  the units in which the elapsed time will be reported.  */
-  template<typename Units>
+  template <typename Units>
   double elapsed(TimerIndex i) const {
     DRAKE_ASSERT(i < timers_.size());
     return timers_[i].elapsed<Units>();
@@ -95,7 +93,7 @@ class Profiler {
    starts.
    @param  i  The identifier for the timer. Only checked in debug mode.
    @tparam Units  the units in which the elapsed time will be reported.  */
-  template<typename Units>
+  template <typename Units>
   double lap(TimerIndex i) {
     DRAKE_ASSERT(i < timers_.size());
     return timers_[i].lap<Units>();
@@ -104,7 +102,7 @@ class Profiler {
   /**  Reports the average lap time across all recorded laps for the ith timer.
    @param  i  The identifier for the timer. Only checked in debug mode.
    @tparam Units  the units in which the elapsed time will be reported.  */
-  template<typename Units>
+  template <typename Units>
   double average(TimerIndex i) const {
     DRAKE_ASSERT(i < timers_.size());
     return timers_[i].average<Units>();
@@ -113,7 +111,7 @@ class Profiler {
   /**  Reports the total time across all recorded laps for the ith timer.
    @param  i  The identifier for the timer. Only checked in debug mode.
    @tparam Units  the units in which the elapsed time will be reported.  */
-  template<typename Units>
+  template <typename Units>
   double total(TimerIndex i) const {
     DRAKE_ASSERT(i < timers_.size());
     return timers_[i].total<Units>();
@@ -130,11 +128,11 @@ class Profiler {
   /**  Reports the average lap time across all recorded laps for
    *the first "count" timers.
    *
-   *	@param		count		The first count timers' average times will be
+   * @param  count  The first count timers' average times will be
    *reported. Only checked in debug mode.
-   *	@param		scale		The scale of the units to report the elapsed
+   * @param  scale  The scale of the units to report the elapsed
    *time in. e.g., 1.0 --> seconds, 0.001 -->, 1e-6 --> microseconds.
-   *	@param		averages	A pointer to an array of floats sufficiently
+   * @param  averages A pointer to an array of floats sufficiently
    *large to hold count values.
    */
   void averages(size_t count, float scale, float* averages) {
@@ -153,9 +151,7 @@ class Profiler {
     return display_string_[i];
   }
 
-  double self_time(TimerIndex i) const {
-    return self_wallclock_[i];
-  }
+  double self_time(TimerIndex i) const { return self_wallclock_[i]; }
 
  private:
   // Singleton pointer.
@@ -194,13 +190,9 @@ TimerIndex PushTimer(TimerIndex index) {
   return Profiler::getMutableInstance().PushTimer(index);
 }
 
-void PopTimer() {
-  return Profiler::getMutableInstance().PopTimer();
-}
+void PopTimer() { return Profiler::getMutableInstance().PopTimer(); }
 
-void UpdateStack(double dt) {
-  Profiler::getMutableInstance().UpdateStack(dt);
-}
+void UpdateStack(double dt) { Profiler::getMutableInstance().UpdateStack(dt); }
 
 double lapTimer(TimerIndex index) {
   return Profiler::getMutableInstance().lap<LapTimer::Units>(index);
@@ -230,12 +222,12 @@ std::string TableOfAverages() {
     ss << fmt::format("{:>15.7g}{:>10}{:>17.7g}{:>15.7g}  {}", time,
                       profiler.laps(i), profiler.total<Seconds>(i),
                       profiler.self_time(i), profiler.displayString(i));
-    //if (i < count - 1)                       
+    // if (i < count - 1)
     ss << "\n";
     self_total += profiler.self_time(i);
-  }  
+  }
   ss << fmt::format("Self Total: {}\n", self_total);
-  return ss.str();  
+  return ss.str();
 }
 
 #endif  // ENABLE_TIMERS

--- a/common/profiler.cc
+++ b/common/profiler.cc
@@ -1,0 +1,241 @@
+#include "drake/common/profiler.h"
+
+#include <memory>
+#include <ratio>
+#include <sstream>
+#include <stack>
+#include <vector>
+
+#include <fmt/format.h>
+
+namespace drake {
+namespace common {
+
+using std::vector;
+
+void Timer::start() { start_ = std::chrono::high_resolution_clock::now(); }
+
+}  // namespace common
+}  // namespace drake
+
+#ifdef ENABLE_TIMERS
+
+namespace {
+
+using drake::common::TimerIndex;
+using drake::common::LapTimer;
+
+/**  Class for storing sets of timers for profiling. This is a singleton class
+ and _not_ threadsafe.  */
+class Profiler {
+ public:
+  /**  Returns a pointer to the singleton instance, creating it as necessary.
+   */
+  static Profiler& getMutableInstance() {
+    if (PROFILER == 0x0) {
+      PROFILER = std::unique_ptr<Profiler>(new Profiler());
+    }
+    return *PROFILER;
+  }
+
+  /**  Creates a lap timer which uses the given label for display.
+   @param  label  The string to display when reporting the profiling results.
+   @returns  The identifier for the created timer.  */
+  TimerIndex addTimer(std::string label) {
+    DRAKE_DEMAND(timers_.size() == display_string_.size());
+    size_t id = timers_.size();
+    timers_.emplace_back();
+    self_wallclock_.push_back(0.0);
+    display_string_.emplace_back(std::move(label));
+    return TimerIndex(id);
+  }
+
+  TimerIndex PushTimer(TimerIndex index) {
+    DRAKE_DEMAND(timers_.size() == display_string_.size());
+    timers_stack_.push(index);
+    return index;
+  }
+
+  void PopTimer() {
+    timers_stack_.pop();
+  }
+
+  void UpdateStack(double total_time) {
+    double& self_time = self_wallclock_[timers_stack_.top()];
+    self_time += total_time;
+    std::stack<TimerIndex> parent_timers(timers_stack_);  // copy.
+    parent_timers.pop();  // remove self.
+    if (!parent_timers.empty()) {
+      self_wallclock_[parent_timers.top()] -= total_time;
+    }
+  }
+
+  /**  Reports the number of timers.  */
+  int timerCount() const { return static_cast<int>(timers_.size()); }
+
+  /**  Starts the ith timer.
+   @param  i  The identifier for the timer. Only checked in debug mode.  */
+  void start(TimerIndex i) {
+    DRAKE_ASSERT(i < timers_.size());
+    timers_[i].start();
+  }
+
+  /**  Reports the time elapsed between this call and the last start for the ith
+       timer.
+   @param  i  The identifier for the timer. Only checked in debug mode.
+   @tparam Units  the units in which the elapsed time will be reported.  */
+  template<typename Units>
+  double elapsed(TimerIndex i) const {
+    DRAKE_ASSERT(i < timers_.size());
+    return timers_[i].elapsed<Units>();
+  }
+
+  /**  Reports the time elapsed from the previous call to lap() or start() to
+   this call for the ith timer. The clock is still "running" and the next lap
+   starts.
+   @param  i  The identifier for the timer. Only checked in debug mode.
+   @tparam Units  the units in which the elapsed time will be reported.  */
+  template<typename Units>
+  double lap(TimerIndex i) {
+    DRAKE_ASSERT(i < timers_.size());
+    return timers_[i].lap<Units>();
+  }
+
+  /**  Reports the average lap time across all recorded laps for the ith timer.
+   @param  i  The identifier for the timer. Only checked in debug mode.
+   @tparam Units  the units in which the elapsed time will be reported.  */
+  template<typename Units>
+  double average(TimerIndex i) const {
+    DRAKE_ASSERT(i < timers_.size());
+    return timers_[i].average<Units>();
+  }
+
+  /**  Reports the total time across all recorded laps for the ith timer.
+   @param  i  The identifier for the timer. Only checked in debug mode.
+   @tparam Units  the units in which the elapsed time will be reported.  */
+  template<typename Units>
+  double total(TimerIndex i) const {
+    DRAKE_ASSERT(i < timers_.size());
+    return timers_[i].total<Units>();
+  }
+
+  /**  Reports the number of laps the ith counter has had.
+   @param  i  The identifier for the timer. Only checked in debug mode.  */
+  int laps(TimerIndex i) const {
+    DRAKE_ASSERT(i < timers_.size());
+    return timers_[i].laps();
+  }
+
+#if 0
+  /**  Reports the average lap time across all recorded laps for
+   *the first "count" timers.
+   *
+   *	@param		count		The first count timers' average times will be
+   *reported. Only checked in debug mode.
+   *	@param		scale		The scale of the units to report the elapsed
+   *time in. e.g., 1.0 --> seconds, 0.001 -->, 1e-6 --> microseconds.
+   *	@param		averages	A pointer to an array of floats sufficiently
+   *large to hold count values.
+   */
+  void averages(size_t count, float scale, float* averages) {
+    assert(count <= timers_.size() &&
+           "Timer index outside of valid range in Profiler::averages()");
+    for (size_t i = 0; i < count; ++i) {
+      averages[i] = timers_[i].average(scale);
+    }
+  }
+#endif
+
+  /**  Returns the display string for the given LapTimer.
+   @param  i  The index of the desired timer. Only validated in debug mode.  */
+  const std::string& displayString(TimerIndex i) const {
+    DRAKE_ASSERT(i < display_string_.size());
+    return display_string_[i];
+  }
+
+  double self_time(TimerIndex i) const {
+    return self_wallclock_[i];
+  }
+
+ private:
+  // Singleton pointer.
+  static std::unique_ptr<Profiler> PROFILER;
+
+  Profiler() = default;
+
+  // The timers.
+  std::vector<LapTimer> timers_;
+
+  // The timer names; there should be one name for each timer.
+  std::vector<::std::string> display_string_;
+
+  std::vector<double> self_wallclock_;
+
+  std::stack<TimerIndex> timers_stack_;
+};
+
+std::unique_ptr<Profiler> Profiler::PROFILER{nullptr};
+
+}  // namespace
+
+TimerIndex addTimer(std::string displayString) {
+  return Profiler::getMutableInstance().addTimer(std::move(displayString));
+}
+
+void startTimer(TimerIndex index) {
+  Profiler::getMutableInstance().start(index);
+}
+
+void stopTimer(TimerIndex index) {
+  Profiler::getMutableInstance().lap<LapTimer::Units>(index);
+}
+
+TimerIndex PushTimer(TimerIndex index) {
+  return Profiler::getMutableInstance().PushTimer(index);
+}
+
+void PopTimer() {
+  return Profiler::getMutableInstance().PopTimer();
+}
+
+void UpdateStack(double dt) {
+  Profiler::getMutableInstance().UpdateStack(dt);
+}
+
+double lapTimer(TimerIndex index) {
+  return Profiler::getMutableInstance().lap<LapTimer::Units>(index);
+}
+
+double lapTimerSeconds(TimerIndex index) {
+  using Seconds = std::ratio<1, 1>;
+  return Profiler::getMutableInstance().lap<Seconds>(index);
+}
+
+double averageTimeInSec(TimerIndex index) {
+  return Profiler::getMutableInstance().average<std::ratio<1, 1>>(index);
+}
+
+std::string TableOfAverages() {
+  using Seconds = std::ratio<1, 1>;
+  const Profiler& profiler = Profiler::getMutableInstance();
+  const int count = profiler.timerCount();
+  std::stringstream ss;
+  ss << "All registered profiles average times:\n";
+  ss << fmt::format("{:>15}{:>10}{:>17}{:>11} {:>10}", "Time/sample (s)",
+                    "Samples", "Total Time (s)", "Self (s)", "Label")
+     << "\n";
+  double self_total = 0;
+  for (TimerIndex i(0); i < count; ++i) {
+    double time = profiler.average<Seconds>(i);
+    ss << fmt::format("{:>15.7g}{:>10}{:>17.7g}{:>15.7g}  {}", time,
+                      profiler.laps(i), profiler.total<Seconds>(i),
+                      profiler.self_time(i), profiler.displayString(i));
+    //if (i < count - 1)                       
+    ss << "\n";
+    self_total += profiler.self_time(i);
+  }  
+  ss << fmt::format("Self Total: {}\n", self_total);
+  return ss.str();  
+}
+
+#endif  // ENABLE_TIMERS

--- a/common/profiler.h
+++ b/common/profiler.h
@@ -1,0 +1,237 @@
+#pragma once
+
+/* Using INSTRUMENT_FUNCTION:
+
+In the source.cc you want to profile:
+  1. #include "drake/common/profiler.h"
+  2. At the top of your function, insert INSTRUMENT_FUNCTION("Description");
+  3. Add "//common:profiler", in the BAZEL.build deps = [].
+
+In the main application:
+  1. Include #include "drake/common/profiler.h"
+  2. Print with: std::cout << TableOfAverages() << "\n";
+  3. Add "//common:profiler", to the depencies.
+  4. Add copts = ["-DENABLE_TIMERS"],
+
+Building:
+Compile with `bazel build --copt=-DENABLE_TIMERS path/to:target`.
+
+TableOfAverages() report per column:
+  - Time/sample: Per call average time in secons (i.e.=[Total time]/[Samples]).
+  - Samples: Number of calls.
+  - Total time: Total time spent by the specific function. This includes self
+    time plus time spent in any other functions called within scope.
+  - Self: Time spent in the scope of the instrumented function. This time does
+    not inlclude the time spent in other instrumented functions, called whether
+    from the scope of this function or transitevely.
+  - Label: label provided to the INSTRUMENT_FUNCTION macro.
+
+Sel total is the sum of all self times. If we don't miss anything important,
+this number should be in close agreement with the total execution time or the
+total execution time of the function or code block we are interested in.
+
+*/
+
+#include <chrono>
+#include <ratio>
+#include <string>
+
+#include "drake/common/type_safe_index.h"
+#include "drake/common/scope_exit.h"
+
+namespace drake {
+namespace common {
+
+/** Index used to identify a registered timer.  */
+using TimerIndex = TypeSafeIndex<class TimerTag>;
+
+// TODO(SeanCurtis-TRI): Need to figure out how to prevent calling timer
+// functions *before* calling start.
+
+/**  Basic timer. A timer that can start and report the amount of time elapsed
+ since calling start().
+
+   times    t₀         t₁      t₂       t₃         t₄            t₅
+          ┄┄┾━━━━━━━━━━┿━━━━━━━┿━━━━━━━━┿━━━━━━━━━━┿━━━━━━━━━━━━━┽┄┄┄┄
+   f()      s()        e()     e()      e()        e()           e()
+
+ The timeline above shows a series of %Timer method invocations: `s()` and
+ `e()`, representing start() and elapsed(), respectively. At each call of
+ elapsed, the duration elapsed between that time and the time that start() was
+ called is returned (i.e., `tᵢ - t₀`, for `i > 0`).  */
+class Timer {
+ public:
+  Timer() = default;
+
+  /**  Starts the timer running.  */
+  void start();
+
+  /**  Reports the time elapsed between this call and the last invocation of
+   start() in the units specified.
+   @tparam Units  the units in which the elapsed time will be reported.  */
+  template <typename Units>
+  double elapsed() const {
+    auto end = std::chrono::high_resolution_clock::now();
+    return std::chrono::duration<double, Units>(end - start_).count();
+  }
+
+ protected:
+  /**  The time (in clock cycles) at which the timer was started.  */
+  std::chrono::time_point<std::chrono::high_resolution_clock> start_;
+};
+
+///////////////////////////////////////////////////////////////////////////
+
+/**  Lap timer. A timer which supports the idea of "laps", a sequence of timer
+ milestones in an otherwise uninterrupted window of time.
+
+   times    t₀         t₁      t₂       t₃         t₄            t₅     t₆
+          ┄┄┾━━━━━━━━━━┿━━━━━━━┿━━━━━━━━┿━━━━━━━━━━┿━━━━━━━━━━━━━┽┄┄┄┄┄┄┤
+   f()      s()        l()     l()      l()        l()           l()    a()
+   laps           1         2        3         4            5
+
+ The timeline above shows a series of %LapTimer method invocations: `s()`,
+ `l()`, and `a()`, representing start(), lap(), and average(), respectively.
+ At each call of lap(), the duration elapsed between that call and the
+ previous invocation is reported, but the clock never stops. Finally, the
+ call to average() reports to the total time spanned by the invocation to
+ start() and the _last_ call to lap() and divides it by the
+ number of calls to lap() (i.e., `(t₅ - t₀) / 5`).
+
+ This class does not store the times for the individual laps; if that
+ granularity of information is needed, the caller should restore the returned
+ lap times.
+
+ The lap timer can also be used to measure the average duration of intervals by
+ alternating calls to start() and lap().
+
+   times    t₀         t₁      t₂       t₃         t₄            t₅     t₆
+          ┄┄┾━━━━━━━━━━┽┄┄┄┄┄┄┄┾━━━━━━━━┽┄┄┄┄┄┄┄┄┄┄┾━━━━━━━━━━━━━┽┄┄┄┄┄┄┤
+   f()      s()        l()     s()      l()        s()           l()    a()
+   laps           1                  2                      3
+
+ The timeline above shows the measurement of three, non-contiguous intervals,
+ each bound by a pair of calls to start() and lap(). In this case, average()
+ will report the average interval length as `(t₅ - t₄ + t₃ - t₂ + t₁ + t₀) / 3`.
+ */
+class LapTimer : public Timer {
+ public:
+  using Units = std::chrono::nanoseconds::period;
+
+  LapTimer() = default;
+
+  /**  Reports the time elapsed from the previous call to lap() or start() to
+   this call.
+   @tparam Units  the units in which the elapsed time will be reported.  */
+  template <typename Units>
+  double lap()  {
+    auto now = std::chrono::high_resolution_clock::now();
+    auto delta = now - start_;
+    start_ = now;
+    total_ += std::chrono::nanoseconds(delta);
+    ++lapCount_;
+    return std::chrono::duration<double, Units>(delta).count();
+  }
+
+  /**  Reports the average lap time across all recorded laps.
+   @tparam Units  the units in which the elapsed time will be reported.  */
+  template <typename Units>
+  double average() const {
+    const double total_time =
+        std::chrono::duration_cast<std::chrono::duration<double, Units>>(total_)
+            .count();
+    return total_time / lapCount_;
+  }
+
+  /**  Reports the total time measured.
+   @tparam Units  the units in which the elapsed time will be reported.  */
+  template <typename Units>
+  double total() const {
+    return std::chrono::duration_cast<std::chrono::duration<double, Units>>(
+               total_)
+        .count();
+  }
+
+  /**  Reports the number of calls to laps.  */
+  int laps() const { return lapCount_; }
+
+ protected:
+  //  The total accrued time of timed intervals (in nanoseconds).
+  std::chrono::nanoseconds total_{0};
+
+  //  The total number of calls to lap().
+  int lapCount_{0};
+};
+
+}  // namespace common
+}  // namespace drake
+
+#ifdef ENABLE_TIMERS
+
+/**  Creates a lap timer which uses the given label for display.
+
+ @param  displayString  The string to display when reporting the profiling
+                        results.
+ @returns  The identifier for the created timer.  */
+drake::common::TimerIndex addTimer(std::string displayString);
+
+/**  Starts the timer with the given identifier.
+
+ @param  index  The timer identifier supplied by addTimer.  */
+void startTimer(drake::common::TimerIndex index);
+
+/**  Stops the timer with the given identifier.
+
+ @param  index  The timer identifier supplied by addTimer.  */
+void stopTimer(drake::common::TimerIndex index);
+
+/**  Lap the ith timer.
+
+ @param  index  The timer identifier supplied by addTimer.  */
+double lapTimer(drake::common::TimerIndex index);
+
+double lapTimerSeconds(drake::common::TimerIndex index);
+drake::common::TimerIndex PushTimer(drake::common::TimerIndex index);
+void PopTimer();
+
+void UpdateStack(double dt);
+
+/**  Reports the average time of the ith timer in seconds.
+
+ @param  index  The timer identifier supplied by addTimer.
+ @returns  The average time of all laps.  */
+double averageTimeInSec(drake::common::TimerIndex index);
+
+/**  Creates a string representing a table of all of the averages.  */
+std::string TableOfAverages();
+
+// N.B. Static variables do not need to be captured in a lambda, they are
+// global!
+// https://stackoverflow.com/questions/13827855/capturing-a-static-variable-by-reference-in-a-c11-lambda
+#define INSTRUMENT_FUNCTION(details_string)      \
+  std::string description = __func__;            \
+  description += "(): ";                         \
+  description += details_string;                 \
+  static const drake::common::TimerIndex timer = \
+      addTimer(std::move(description));          \
+  PushTimer(timer);                              \
+  startTimer(timer);                             \
+  drake::ScopeExit guard([]() {                  \
+    const double dt = lapTimerSeconds(timer);    \
+    UpdateStack(dt);                             \
+    PopTimer();                                  \
+  })
+
+#else  // not defined ENABLE_TIMERS
+
+#define addTimer(displayString) (common::TimerIndex(0))
+#define startTimer(index) ((void)index)
+#define stopTimer(index) ((void)index)
+#define lapTimer(index) ((void)index)
+#define PushTimer(index) ((void)index)
+#define PopTimer()
+#define averageTimeInSec(index) ((void)index)
+#define TableOfAverages() ("Profiling turned off")
+#define INSTRUMENT_FUNCTION(details_string) ((void)details_string)
+
+#endif  // ENABLE_TIMERS

--- a/common/profiler.h
+++ b/common/profiler.h
@@ -35,9 +35,10 @@ total execution time of the function or code block we are interested in.
 #include <chrono>
 #include <ratio>
 #include <string>
+#include <utility>
 
-#include "drake/common/type_safe_index.h"
 #include "drake/common/scope_exit.h"
+#include "drake/common/type_safe_index.h"
 
 namespace drake {
 namespace common {
@@ -124,7 +125,7 @@ class LapTimer : public Timer {
    this call.
    @tparam Units  the units in which the elapsed time will be reported.  */
   template <typename Units>
-  double lap()  {
+  double lap() {
     auto now = std::chrono::high_resolution_clock::now();
     auto delta = now - start_;
     start_ = now;

--- a/common/test/profiler_test.cc
+++ b/common/test/profiler_test.cc
@@ -1,0 +1,100 @@
+#include "drake/common/profiler.h"
+
+#include <chrono>
+#include <ratio>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace common {
+namespace {
+
+#ifdef ENABLE_TIMERS
+
+using std::chrono::high_resolution_clock;
+using std::this_thread::sleep_for;
+using std::vector;
+
+// Simply confirm that the clock is giving us the resolution we want (ns).
+GTEST_TEST(ProfilerTest, ConfirmHighResolution) {
+  // The period should be 1 / 1e9 (i.e. nanosecond resolution).
+  EXPECT_EQ(1000000000, high_resolution_clock::period::den);
+}
+
+// Tests the underlying Timer class.
+GTEST_TEST(ProfilerTest, Timer) {
+  Timer t;
+  const std::chrono::duration<double, std::milli> sleep_time(250.);
+  t.start();
+
+  sleep_for(sleep_time);
+  const double elapsed = t.elapsed<std::milli>();
+  EXPECT_GE(elapsed, sleep_time.count());
+  // This may be a fragile test; sleeping only guarantees that the thread will
+  // be asleep *at least* the sleep time. I'm assuming it wont' double up.
+  EXPECT_LT(elapsed, sleep_time.count() * 2);
+}
+
+// Tests the lap timer's behavior in tracking laps, reporting lap durations,
+// and the average, all with common units.
+GTEST_TEST(ProfilerTest, LapTimer) {
+  const std::chrono::duration<double, std::milli> sleep_time(250.);
+  const int kLapCount = 10;
+  vector<double> lap_times(10, -1.);
+  LapTimer timer;
+  timer.start();
+  for (int i = 0; i < kLapCount; ++i) {
+    sleep_for(sleep_time);
+    lap_times[i] = timer.lap<std::milli>();
+  }
+  EXPECT_EQ(kLapCount, timer.laps());
+  double expected_mean_ms = 0;
+  for (double t : lap_times) expected_mean_ms += t;
+  expected_mean_ms /= kLapCount;
+  EXPECT_NEAR(expected_mean_ms, timer.average<std::milli>(), 1);
+  sleep_for(sleep_time);
+  // Delaying an arbitrary amount of time *after* the last lap, will not change
+  // the mean lap duration.
+  EXPECT_NEAR(expected_mean_ms, timer.average<std::milli>(), 1);
+
+  EXPECT_NEAR(expected_mean_ms * 1000, timer.average<std::micro>(), 1);
+  EXPECT_NEAR(expected_mean_ms * 1000000, timer.average<std::nano>(), 1);
+  EXPECT_NEAR(expected_mean_ms / 10, timer.average<std::centi>(), 1);
+  // Note: the gtest macro does *not* deal well with the nested templated types.
+  // This is why we evaluate mean seconds outside of the EXPECT_EQ.
+  const double mean_seconds = timer.average<std::ratio<1, 1>>();
+  EXPECT_NEAR(expected_mean_ms / 1000, mean_seconds, 1);
+}
+
+GTEST_TEST(ProfileTester, LapTimerForIntervals) {
+  const std::chrono::duration<double, std::milli> sleep_time(250.);
+  const int kLapCount = 10;
+  vector<double> lap_times(10, -1.);
+  LapTimer timer;
+  timer.start();
+  for (int i = 0; i < kLapCount; ++i) {
+    sleep_for(sleep_time);
+    lap_times[i] = timer.lap<std::milli>();
+    sleep_for(sleep_time);
+    timer.start();
+  }
+
+  EXPECT_EQ(kLapCount, timer.laps());
+
+  double expected_mean_ms = 0;
+  for (double t : lap_times) expected_mean_ms += t;
+  expected_mean_ms /= kLapCount;
+  EXPECT_NEAR(expected_mean_ms, timer.average<std::milli>(), 1);
+  sleep_for(sleep_time);
+  // Delaying an arbitrary amount of time *after* the last lap, will not change
+  // the mean lap duration.
+  EXPECT_NEAR(expected_mean_ms, timer.average<std::milli>(), 1);
+}
+
+#endif  // ENABLE_TIMERS
+
+}  // namespace
+}  // namespace common
+}  // namespace drake

--- a/traj_opt/BUILD.bazel
+++ b/traj_opt/BUILD.bazel
@@ -48,6 +48,7 @@ drake_cc_library(
     deps = [
         ":penta_diagonal_matrix",
         "//common:essential",
+        "//common:profiler",
     ],
 )
 
@@ -68,6 +69,7 @@ drake_cc_library(
         ":trajectory_optimizer_workspace",
         ":velocity_partials",
         "//common:essential",
+        "//common:profiler",
         "//geometry:scene_graph_inspector",
         "//multibody/plant",
     ],

--- a/traj_opt/examples/BUILD.bazel
+++ b/traj_opt/examples/BUILD.bazel
@@ -124,6 +124,7 @@ drake_cc_binary(
     deps = [
         ":example_base",
         "//common:find_resource",
+        "//common:profiler",
         "//multibody/parsing",
         "//multibody/plant",
     ],

--- a/traj_opt/examples/spinner.cc
+++ b/traj_opt/examples/spinner.cc
@@ -1,4 +1,7 @@
+#include <iostream>
+
 #include "drake/common/find_resource.h"
+#include "drake/common/profiler.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/traj_opt/examples/example_base.h"
@@ -31,5 +34,6 @@ int main() {
   drake::traj_opt::examples::spinner::SpinnerExample spinner_example;
   spinner_example.SolveTrajectoryOptimization(
       "drake/traj_opt/examples/spinner.yaml");
+  std::cout << TableOfAverages() << "\n";    
   return 0;
 }

--- a/traj_opt/examples/spinner.cc
+++ b/traj_opt/examples/spinner.cc
@@ -31,9 +31,13 @@ class SpinnerExample : public TrajOptExample {
 }  // namespace drake
 
 int main() {
+  // Solve the optimization problem
   drake::traj_opt::examples::spinner::SpinnerExample spinner_example;
   spinner_example.SolveTrajectoryOptimization(
       "drake/traj_opt/examples/spinner.yaml");
-  std::cout << TableOfAverages() << "\n";    
+
+  // Print speed profiling info
+  std::cout << std::endl;
+  std::cout << TableOfAverages() << std::endl;
   return 0;
 }

--- a/traj_opt/penta_diagonal_solver.h
+++ b/traj_opt/penta_diagonal_solver.h
@@ -5,6 +5,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/traj_opt/penta_diagonal_matrix.h"
+#include "drake/common/profiler.h"
 
 namespace drake {
 namespace traj_opt {
@@ -109,8 +110,9 @@ PentaDiagonalFactorization<kBlockSize>::PentaDiagonalFactorization(
 
 template <int kBlockSize>
 void PentaDiagonalFactorization<kBlockSize>::Factorize(
-    const PentaDiagonalMatrix<double>& M) {
+    const PentaDiagonalMatrix<double>& M) { 
   DRAKE_DEMAND(M.is_symmetric());
+  INSTRUMENT_FUNCTION("Factorization by Thomas-algorithm.");
 
   const int k = M.block_size();
   const int num_blocks = M.block_rows();
@@ -185,6 +187,7 @@ template <int kBlockSize>
 void PentaDiagonalFactorization<kBlockSize>::SolveInPlace(
     EigenPtr<Eigen::VectorXd> b) {
   DRAKE_DEMAND(b->size() == size());
+  INSTRUMENT_FUNCTION("Backward substitution.");
 
   const int block_size = factorization_.block_size;
   const int num_blocks = factorization_.num_blocks;

--- a/traj_opt/penta_diagonal_solver.h
+++ b/traj_opt/penta_diagonal_solver.h
@@ -4,8 +4,8 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
-#include "drake/traj_opt/penta_diagonal_matrix.h"
 #include "drake/common/profiler.h"
+#include "drake/traj_opt/penta_diagonal_matrix.h"
 
 namespace drake {
 namespace traj_opt {
@@ -110,7 +110,7 @@ PentaDiagonalFactorization<kBlockSize>::PentaDiagonalFactorization(
 
 template <int kBlockSize>
 void PentaDiagonalFactorization<kBlockSize>::Factorize(
-    const PentaDiagonalMatrix<double>& M) { 
+    const PentaDiagonalMatrix<double>& M) {
   DRAKE_DEMAND(M.is_symmetric());
   INSTRUMENT_FUNCTION("Factorization by Thomas-algorithm.");
 

--- a/traj_opt/trajectory_optimizer.cc
+++ b/traj_opt/trajectory_optimizer.cc
@@ -248,7 +248,7 @@ void TrajectoryOptimizer<T>::CalcInverseDynamicsSingleTimeStep(
 template <typename T>
 void TrajectoryOptimizer<T>::CalcContactForceContribution(
     const Context<T>& context, MultibodyForces<T>* forces) const {
-  INSTRUMENT_FUNCTION("Computes contact forces.");    
+  INSTRUMENT_FUNCTION("Computes contact forces.");
 
   using std::abs;
   using std::max;
@@ -536,7 +536,7 @@ template <typename T>
 void TrajectoryOptimizer<T>::CalcInverseDynamicsPartials(
     const TrajectoryOptimizerState<T>& state,
     InverseDynamicsPartials<T>* id_partials) const {
-  INSTRUMENT_FUNCTION("Computes of dtau/dq.");    
+  INSTRUMENT_FUNCTION("Computes of dtau/dq.");
   switch (params_.gradients_method) {
     case GradientsMethod::kForwardDifferences: {
       CalcInverseDynamicsPartialsFiniteDiff(state, id_partials);
@@ -2187,7 +2187,7 @@ SolverFlag TrajectoryOptimizer<double>::SolveWithTrustRegion(
     TrajectoryOptimizerSolution<double>* solution,
     TrajectoryOptimizerStats<double>* stats,
     ConvergenceReason* reason_out) const {
-  INSTRUMENT_FUNCTION("Trust region solver.");    
+  INSTRUMENT_FUNCTION("Trust region solver.");
   using std::min;
   // Allocate a state variable to store q and everything that is computed from q
   TrajectoryOptimizerState<double> state = CreateState();

--- a/traj_opt/trajectory_optimizer.cc
+++ b/traj_opt/trajectory_optimizer.cc
@@ -128,6 +128,7 @@ const T TrajectoryOptimizer<T>::EvalCost(
 template <typename T>
 T TrajectoryOptimizer<T>::CalcCost(
     const TrajectoryOptimizerState<T>& state) const {
+  INSTRUMENT_FUNCTION("Computes the total cost.");
   const std::vector<VectorX<T>>& v = EvalV(state);
   const std::vector<VectorX<T>>& tau = EvalTau(state);
   T cost = CalcCost(state.q(), v, tau, &state.workspace);
@@ -536,7 +537,7 @@ template <typename T>
 void TrajectoryOptimizer<T>::CalcInverseDynamicsPartials(
     const TrajectoryOptimizerState<T>& state,
     InverseDynamicsPartials<T>* id_partials) const {
-  INSTRUMENT_FUNCTION("Computes of dtau/dq.");
+  INSTRUMENT_FUNCTION("Computes dtau/dq.");
   switch (params_.gradients_method) {
     case GradientsMethod::kForwardDifferences: {
       CalcInverseDynamicsPartialsFiniteDiff(state, id_partials);
@@ -1164,6 +1165,7 @@ void TrajectoryOptimizer<T>::CalcGradientFiniteDiff(
 template <typename T>
 void TrajectoryOptimizer<T>::CalcGradient(
     const TrajectoryOptimizerState<T>& state, EigenPtr<VectorX<T>> g) const {
+  INSTRUMENT_FUNCTION("Assembly of the gradient.");
   const double dt = time_step();
   const int nq = plant().num_positions();
   TrajectoryOptimizerWorkspace<T>* workspace = &state.workspace;

--- a/traj_opt/trajectory_optimizer.cc
+++ b/traj_opt/trajectory_optimizer.cc
@@ -7,6 +7,7 @@
 #include <limits>
 #include <string>
 
+#include "drake/common/profiler.h"
 #include "drake/geometry/scene_graph_inspector.h"
 #include "drake/multibody/math/spatial_algebra.h"
 #include "drake/systems/framework/diagram.h"
@@ -227,6 +228,8 @@ template <typename T>
 void TrajectoryOptimizer<T>::CalcInverseDynamicsSingleTimeStep(
     const Context<T>& context, const VectorX<T>& a,
     TrajectoryOptimizerWorkspace<T>* workspace, VectorX<T>* tau) const {
+  INSTRUMENT_FUNCTION("Computes inverse dynamics.");
+
   plant().CalcForceElementsContribution(context, &workspace->f_ext);
 
   // Add in contact force contribution to f_ext
@@ -245,6 +248,8 @@ void TrajectoryOptimizer<T>::CalcInverseDynamicsSingleTimeStep(
 template <typename T>
 void TrajectoryOptimizer<T>::CalcContactForceContribution(
     const Context<T>& context, MultibodyForces<T>* forces) const {
+  INSTRUMENT_FUNCTION("Computes contact forces.");    
+
   using std::abs;
   using std::max;
   using std::pow;
@@ -531,6 +536,7 @@ template <typename T>
 void TrajectoryOptimizer<T>::CalcInverseDynamicsPartials(
     const TrajectoryOptimizerState<T>& state,
     InverseDynamicsPartials<T>* id_partials) const {
+  INSTRUMENT_FUNCTION("Computes of dtau/dq.");    
   switch (params_.gradients_method) {
     case GradientsMethod::kForwardDifferences: {
       CalcInverseDynamicsPartialsFiniteDiff(state, id_partials);
@@ -1256,6 +1262,7 @@ void TrajectoryOptimizer<T>::CalcHessian(
   DRAKE_DEMAND(H->is_symmetric());
   DRAKE_DEMAND(H->block_rows() == num_steps() + 1);
   DRAKE_DEMAND(H->block_size() == plant().num_positions());
+  INSTRUMENT_FUNCTION("Assembly of the Hessian.");
 
   // Some convienient aliases
   const double dt = time_step();
@@ -1336,6 +1343,7 @@ const PentaDiagonalMatrix<T>& TrajectoryOptimizer<T>::EvalHessian(
     const TrajectoryOptimizerState<T>& state) const {
   if (!state.cache().hessian_up_to_date) {
     CalcHessian(state, &state.mutable_cache().hessian);
+    state.mutable_cache().hessian_up_to_date = true;
   }
   return state.cache().hessian;
 }
@@ -1888,6 +1896,8 @@ template <>
 bool TrajectoryOptimizer<double>::CalcDoglegPoint(
     const TrajectoryOptimizerState<double>& state, const double Delta,
     VectorXd* dq, VectorXd* dqH) const {
+  INSTRUMENT_FUNCTION("Find search direction with dogleg method.");
+
   // N.B. We'll rescale pU and pH by Δ to avoid roundoff error
   const VectorXd& g = EvalGradient(state);
   const PentaDiagonalMatrix<double>& H = EvalHessian(state);
@@ -1964,6 +1974,8 @@ SolverFlag TrajectoryOptimizer<double>::Solve(
     const std::vector<VectorXd>& q_guess,
     TrajectoryOptimizerSolution<double>* solution,
     TrajectoryOptimizerStats<double>* stats, ConvergenceReason* reason) const {
+  INSTRUMENT_FUNCTION("Main entry point.");
+
   // The guess must be consistent with the initial condition
   DRAKE_DEMAND(q_guess[0] == prob_.q_init);
   DRAKE_DEMAND(static_cast<int>(q_guess.size()) == num_steps() + 1);
@@ -2175,6 +2187,7 @@ SolverFlag TrajectoryOptimizer<double>::SolveWithTrustRegion(
     TrajectoryOptimizerSolution<double>* solution,
     TrajectoryOptimizerStats<double>* stats,
     ConvergenceReason* reason_out) const {
+  INSTRUMENT_FUNCTION("Trust region solver.");    
   using std::min;
   // Allocate a state variable to store q and everything that is computed from q
   TrajectoryOptimizerState<double> state = CreateState();

--- a/traj_opt/trajectory_optimizer.h
+++ b/traj_opt/trajectory_optimizer.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "drake/common/eigen_types.h"
+#include "drake/common/profiler.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/traj_opt/inverse_dynamics_partials.h"
 #include "drake/traj_opt/penta_diagonal_matrix.h"
@@ -104,6 +105,7 @@ class TrajectoryOptimizer {
    * @return TrajectoryOptimizerState
    */
   TrajectoryOptimizerState<T> CreateState() const {
+    INSTRUMENT_FUNCTION("Creates state object with caching.");
     if (diagram_ != nullptr) {
       return TrajectoryOptimizerState<T>(num_steps(), *diagram_, plant());
     }


### PR DESCRIPTION
I added notes on how to edit/build and read the logs at the very top of `common/profiler.h`

Run spinner with `bazel run --copt=-DENABLE_TIMERS traj_opt/examples:spinner` for an example.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vincekurtz/drake/44)
<!-- Reviewable:end -->
