### PR TITLE
Dense algebra patch

### DIFF
--- a/traj_opt/examples/allegro_hand.yaml
+++ b/traj_opt/examples/allegro_hand.yaml
@@ -82,7 +82,7 @@ time_step : 0.05    # Discretization timestep (seconds)
 num_steps : 40      # number of timesteps
 
 # Solver parameters
-max_iters : 500             # maximum Gauss-Newton iterations
+max_iters : 50              # maximum Gauss-Newton iterations
 method : "trust_region"     # solver method, {linesearch, trust_region}
 tolerances:
   rel_cost_reduction: 1e-4


### PR DESCRIPTION
- Adds a check that the proposed step `Δq` is along a descent direction
- Uses dense algebra to solve `H Δq = - g` (for the trust region solver)

This patch makes solve times significantly slower, and we should revert to sparse algebra once the penta-diagonal solver is fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vincekurtz/drake/49)
<!-- Reviewable:end -->
