### PR TITLE
Use different models for simulation and optimization

### DIFF
--- a/traj_opt/examples/dual_jaco.cc
+++ b/traj_opt/examples/dual_jaco.cc
@@ -1,4 +1,5 @@
 #include "drake/common/find_resource.h"
+#include "drake/geometry/proximity_properties.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/traj_opt/examples/example_base.h"
@@ -9,7 +10,10 @@ namespace examples {
 namespace dual_jaco {
 
 using Eigen::Vector3d;
+using geometry::AddContactMaterial;
+using geometry::AddRigidHydroelasticProperties;
 using geometry::Box;
+using geometry::ProximityProperties;
 using math::RigidTransformd;
 using multibody::CoulombFriction;
 using multibody::ModelInstanceIndex;
@@ -18,11 +22,7 @@ using multibody::Parser;
 
 class DualJacoExample : public TrajOptExample {
   void CreatePlantModel(MultibodyPlant<double>* plant) const final {
-    const Vector4<double> blue(0.1, 0.3, 0.5, 1.0);
-    const Vector4<double> green(0.3, 0.6, 0.4, 1.0);
-    const Vector4<double> black(0.0, 0.0, 0.0, 1.0);
-
-    // Add a jaco arms
+    // Add jaco arms
     std::string robot_file = FindResourceOrThrow(
         "drake/traj_opt/examples/models/j2s7s300_arm_sphere_collision_v2.sdf");
 
@@ -46,12 +46,50 @@ class DualJacoExample : public TrajOptExample {
     Parser(plant).AddAllModelsFromFile(manipuland_file);
 
     // Add the ground
+    const Vector4<double> green(0.3, 0.6, 0.4, 1.0);
     RigidTransformd X_ground(Vector3d(0.0, 0.0, -0.5));
     plant->RegisterVisualGeometry(plant->world_body(), X_ground, Box(25, 25, 1),
                                   "ground", green);
     plant->RegisterCollisionGeometry(plant->world_body(), X_ground,
                                      Box(25, 25, 1), "ground",
                                      CoulombFriction<double>(0.5, 0.5));
+  }
+
+  void CreatePlantModelForSimulation(
+      MultibodyPlant<double>* plant) const final {
+    // Add jaco arms, including gravity
+    std::string robot_file = FindResourceOrThrow(
+        "drake/traj_opt/examples/models/j2s7s300_arm_sphere_collision_v2.sdf");
+
+    ModelInstanceIndex jaco_left =
+        Parser(plant).AddModelFromFile(robot_file, "jaco_left");
+    RigidTransformd X_left(Vector3d(0, 0.27, 0.11));
+    plant->WeldFrames(plant->world_frame(),
+                      plant->GetFrameByName("base", jaco_left), X_left);
+
+    ModelInstanceIndex jaco_right =
+        Parser(plant).AddModelFromFile(robot_file, "jaco_right");
+    RigidTransformd X_right(Vector3d(0, -0.27, 0.11));
+    plant->WeldFrames(plant->world_frame(),
+                      plant->GetFrameByName("base", jaco_right), X_right);
+
+    // Add a manipuland with compliant hydroelastic contact
+    std::string manipuland_file = FindResourceOrThrow(
+        "drake/traj_opt/examples/models/box_15cm_hydro.sdf");
+    Parser(plant).AddAllModelsFromFile(manipuland_file);
+
+    // Add the ground with rigid hydroelastic contact
+    const Vector4<double> green(0.3, 0.6, 0.4, 1.0);
+    RigidTransformd X_ground(Vector3d(0.0, 0.0, -0.5));
+    plant->RegisterVisualGeometry(plant->world_body(), X_ground, Box(25, 25, 1),
+                                  "ground", green);
+    ProximityProperties ground_proximity;
+    AddContactMaterial({}, {}, CoulombFriction<double>(0.5, 0.5),
+                       &ground_proximity);
+    AddRigidHydroelasticProperties(0.1, &ground_proximity);
+    plant->RegisterCollisionGeometry(plant->world_body(), X_ground,
+                                     Box(25, 25, 1), "ground",
+                                     ground_proximity);
   }
 };
 

--- a/traj_opt/examples/dual_jaco.yaml
+++ b/traj_opt/examples/dual_jaco.yaml
@@ -9,7 +9,7 @@
 q_init : [0.0, 1.7, 0.0, 5.0,-1.0, 4.5, 0.0,   # left arm positions
           0.0, 1.7, 0.0, 5.0, 1.0, 4.5, 0.0,   # right arm positions
           1.0, 0.0, 0.0, 0.0,                  # box orientation
-          0.5, 0.0, 0.08]                       # box position
+          0.5, 0.0, 0.1]                       # box position
 v_init : [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
           0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
           0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
@@ -18,7 +18,7 @@ v_init : [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 q_nom_start : [0.0, 1.7, 0.0, 5.0,-1.0, 4.5, 0.0,
                0.0, 1.7, 0.0, 5.0, 1.0, 4.5, 0.0,
                1.0, 0.0, 0.0, 0.0,
-               0.5, 0.0, 0.08]
+               0.5, 0.0, 0.1]
 q_nom_end : [0.0, 1.7, 0.0, 5.0,-1.0, 4.5, 0.0,
              0.0, 1.7, 0.0, 5.0, 1.0, 4.5, 0.0,
              0.7, 0.0, 0.0,-0.3,
@@ -59,7 +59,7 @@ time_step : 0.05    # Discretization timestep (seconds)
 num_steps : 40      # number of timesteps
 
 # Solver parameters
-max_iters : 200             # maximum Gauss-Newton iterations
+max_iters : 50              # maximum Gauss-Newton iterations
 method : "trust_region"     # solver method, {linesearch, trust_region}
 scaling : true
 equality_constraints : true
@@ -106,9 +106,9 @@ friction_coefficient : 0.5  # Coefficient of friction.
 stiction_velocity: 0.05      # Regularization velocity, in m/s.
 
 # MPC parameters
-mpc : false
+mpc : true
 mpc_iters : 10
-controller_frequency : 5.0
+controller_frequency : 0.1
 sim_time : 5
 sim_time_step : 1e-3
 sim_realtime_rate : 1.0

--- a/traj_opt/examples/dual_jaco.yaml
+++ b/traj_opt/examples/dual_jaco.yaml
@@ -106,9 +106,9 @@ friction_coefficient : 0.5  # Coefficient of friction.
 stiction_velocity: 0.05      # Regularization velocity, in m/s.
 
 # MPC parameters
-mpc : true
+mpc : false
 mpc_iters : 10
-controller_frequency : 0.1
+controller_frequency : 5.0
 sim_time : 5
 sim_time_step : 1e-3
 sim_realtime_rate : 1.0

--- a/traj_opt/examples/example_base.cc
+++ b/traj_opt/examples/example_base.cc
@@ -50,7 +50,7 @@ void TrajOptExample::RunModelPredictiveControl(
   MultibodyPlantConfig config;
   config.time_step = options.sim_time_step;
   auto [plant, scene_graph] = AddMultibodyPlant(config, &builder);
-  CreatePlantModel(&plant);
+  CreatePlantModelForSimulation(&plant);
   plant.Finalize();
 
   const int nq = plant.num_positions();

--- a/traj_opt/examples/example_base.h
+++ b/traj_opt/examples/example_base.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <iostream> //debug
 
 #include "drake/common/find_resource.h"
 #include "drake/geometry/scene_graph.h"
@@ -71,6 +72,18 @@ class TrajOptExample {
    * @param plant the MultibodyPlant that we'll add the system to.
    */
   virtual void CreatePlantModel(MultibodyPlant<double>*) const {}
+
+  /**
+   * Create a MultibodyPlant model of the system to use for simulation (i.e., to
+   * test MPC). The default behavior is to use the same model that we use for
+   * optimization.
+   *
+   * @param plant the MultibodyPlant that we'll add the system to.
+   */
+  virtual void CreatePlantModelForSimulation(
+      MultibodyPlant<double>* plant) const {
+    CreatePlantModel(plant);
+  }
 
   /**
    * Play back the given trajectory on the Drake visualizer

--- a/traj_opt/examples/example_base.h
+++ b/traj_opt/examples/example_base.h
@@ -5,7 +5,6 @@
 #include <string>
 #include <thread>
 #include <vector>
-#include <iostream> //debug
 
 #include "drake/common/find_resource.h"
 #include "drake/geometry/scene_graph.h"

--- a/traj_opt/examples/jaco.cc
+++ b/traj_opt/examples/jaco.cc
@@ -1,8 +1,8 @@
 #include "drake/common/find_resource.h"
+#include "drake/geometry/proximity_properties.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/traj_opt/examples/example_base.h"
-#include "drake/geometry/proximity_properties.h"
 
 namespace drake {
 namespace traj_opt {
@@ -10,10 +10,10 @@ namespace examples {
 namespace jaco {
 
 using Eigen::Vector3d;
-using geometry::Box;
-using geometry::ProximityProperties;
 using geometry::AddContactMaterial;
 using geometry::AddRigidHydroelasticProperties;
+using geometry::Box;
+using geometry::ProximityProperties;
 using math::RigidTransformd;
 using multibody::CoulombFriction;
 using multibody::ModelInstanceIndex;
@@ -22,9 +22,7 @@ using multibody::Parser;
 
 class JacoExample : public TrajOptExample {
   void CreatePlantModel(MultibodyPlant<double>* plant) const final {
-    const Vector4<double> green(0.3, 0.6, 0.4, 1.0);
-
-    // Add a jaco arm
+    // Add a jaco arm without gravity
     std::string robot_file = FindResourceOrThrow(
         "drake/traj_opt/examples/models/j2s7s300_arm_sphere_collision_v2.sdf");
     ModelInstanceIndex jaco = Parser(plant).AddModelFromFile(robot_file);
@@ -33,12 +31,13 @@ class JacoExample : public TrajOptExample {
                       X_jaco);
     plant->disable_gravity(jaco);
 
-    // Add a manipuland
+    // Add a manipuland with sphere contact
     std::string manipuland_file =
         FindResourceOrThrow("drake/traj_opt/examples/models/box_15cm.sdf");
     Parser(plant).AddAllModelsFromFile(manipuland_file);
 
     // Add the ground
+    const Vector4<double> green(0.3, 0.6, 0.4, 1.0);
     RigidTransformd X_ground(Vector3d(0.0, 0.0, -0.5));
     plant->RegisterVisualGeometry(plant->world_body(), X_ground, Box(25, 25, 1),
                                   "ground", green);
@@ -52,9 +51,7 @@ class JacoExample : public TrajOptExample {
 
   void CreatePlantModelForSimulation(
       MultibodyPlant<double>* plant) const final {
-    const Vector4<double> green(0.3, 0.6, 0.4, 1.0);
-
-    // Add a jaco arm
+    // Add a jaco arm, including gravity
     std::string robot_file = FindResourceOrThrow(
         "drake/traj_opt/examples/models/j2s7s300_arm_sphere_collision_v2.sdf");
     Parser(plant).AddModelFromFile(robot_file);
@@ -68,6 +65,7 @@ class JacoExample : public TrajOptExample {
     Parser(plant).AddAllModelsFromFile(manipuland_file);
 
     // Add the ground with rigid hydroelastic contact
+    const Vector4<double> green(0.3, 0.6, 0.4, 1.0);
     RigidTransformd X_ground(Vector3d(0.0, 0.0, -0.5));
     plant->RegisterVisualGeometry(plant->world_body(), X_ground, Box(25, 25, 1),
                                   "ground", green);

--- a/traj_opt/examples/jaco.cc
+++ b/traj_opt/examples/jaco.cc
@@ -18,9 +18,7 @@ using multibody::Parser;
 
 class JacoExample : public TrajOptExample {
   void CreatePlantModel(MultibodyPlant<double>* plant) const final {
-    const Vector4<double> blue(0.1, 0.3, 0.5, 1.0);
     const Vector4<double> green(0.3, 0.6, 0.4, 1.0);
-    const Vector4<double> black(0.0, 0.0, 0.0, 1.0);
 
     // Add a jaco arm
     std::string robot_file = FindResourceOrThrow(
@@ -46,6 +44,33 @@ class JacoExample : public TrajOptExample {
     // N.B. When combined with the friction coefficient of the box according to
     // μ = 2μₘμₙ/(μₘ + μₙ), this gives a friction coefficient of roughly 0.1
     // between the box and the ground.
+  }
+
+  void CreatePlantModelForSimulation(
+      MultibodyPlant<double>* plant) const final {
+    const Vector4<double> green(0.3, 0.6, 0.4, 1.0);
+
+    // Add a jaco arm
+    std::string robot_file = FindResourceOrThrow(
+        "drake/traj_opt/examples/models/j2s7s300_arm_sphere_collision_v2.sdf");
+    ModelInstanceIndex jaco = Parser(plant).AddModelFromFile(robot_file);
+    RigidTransformd X_jaco(Vector3d(0, -0.27, 0.11));
+    plant->WeldFrames(plant->world_frame(), plant->GetFrameByName("base"),
+                      X_jaco);
+    plant->disable_gravity(jaco);
+
+    // Add a manipuland
+    std::string manipuland_file =
+        FindResourceOrThrow("drake/traj_opt/examples/models/box_15cm.sdf");
+    Parser(plant).AddAllModelsFromFile(manipuland_file);
+
+    // Add the ground
+    RigidTransformd X_ground(Vector3d(0.0, 0.0, -0.5));
+    plant->RegisterVisualGeometry(plant->world_body(), X_ground, Box(25, 25, 1),
+                                  "ground", green);
+    plant->RegisterCollisionGeometry(plant->world_body(), X_ground,
+                                     Box(25, 25, 1), "ground",
+                                     CoulombFriction<double>(0.5, 0.5));
   }
 };
 

--- a/traj_opt/examples/jaco.yaml
+++ b/traj_opt/examples/jaco.yaml
@@ -96,9 +96,9 @@ friction_coefficient : 0.1  # Coefficient of friction.
 stiction_velocity: 0.05      # Regularization velocity, in m/s.
 
 # MPC parameters
-mpc : false
+mpc : true
 mpc_iters : 5
-controller_frequency : 5
+controller_frequency : 0.1
 sim_time : 5
 sim_time_step : 1e-3
 sim_realtime_rate : 1.0

--- a/traj_opt/examples/jaco.yaml
+++ b/traj_opt/examples/jaco.yaml
@@ -96,9 +96,9 @@ friction_coefficient : 0.1  # Coefficient of friction.
 stiction_velocity: 0.05      # Regularization velocity, in m/s.
 
 # MPC parameters
-mpc : true
+mpc : false
 mpc_iters : 5
-controller_frequency : 0.1
+controller_frequency : 5.0
 sim_time : 5
 sim_time_step : 1e-3
 sim_realtime_rate : 0.0

--- a/traj_opt/examples/jaco.yaml
+++ b/traj_opt/examples/jaco.yaml
@@ -101,7 +101,7 @@ mpc_iters : 5
 controller_frequency : 0.1
 sim_time : 5
 sim_time_step : 1e-3
-sim_realtime_rate : 1.0
+sim_realtime_rate : 0.0
 
 feed_forward : false
 Kp: [500, 500, 250, 500, 250, 250, 250,

--- a/traj_opt/examples/models/box_15cm_hydro.sdf
+++ b/traj_opt/examples/models/box_15cm_hydro.sdf
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<sdf version="1.7">
+  <model name="box_15cm">
+    <!-- The model for a solid box of uniform density. -->
+    <link name="box">
+      <inertial>
+        <mass>0.55</mass>
+        <inertia>
+          <ixx>0.0020625</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.0020625</iyy>
+          <iyz>0</iyz>
+          <izz>0.0020625</izz>
+        </inertia>
+      </inertial>
+
+      <visual name="box_visual">
+        <geometry>
+          <box>
+            <size>0.15 0.15 0.15</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>1 0 0 0.8</diffuse>
+        </material>
+      </visual>
+
+      <collision name="box_collision">
+        <pose> 0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.15 0.15 0.15</size>
+          </box>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>0.5</mu>
+              <mu2>0.5</mu2>
+            </ode>
+          </friction>
+        </surface>
+        <drake:proximity_properties>
+          <drake:compliant_hydroelastic/>
+          <drake:mesh_resolution_hint>0.1</drake:mesh_resolution_hint>
+          <drake:hydroelastic_modulus>5e7</drake:hydroelastic_modulus>
+          <drake:hunt_crossley_dissipation>1.25</drake:hunt_crossley_dissipation>
+        </drake:proximity_properties>
+      </collision>
+    </link>
+  </model>
+</sdf>

--- a/traj_opt/examples/models/j2s7s300_arm_sphere_collision_v2.sdf
+++ b/traj_opt/examples/models/j2s7s300_arm_sphere_collision_v2.sdf
@@ -382,6 +382,12 @@ Later edited by hand to:
           </ode>
           </friction>
         </surface>
+        <drake:proximity_properties>
+          <drake:compliant_hydroelastic/>
+          <drake:mesh_resolution_hint>0.1</drake:mesh_resolution_hint>
+          <drake:hydroelastic_modulus>5e7</drake:hydroelastic_modulus>
+          <drake:hunt_crossley_dissipation>1.25</drake:hunt_crossley_dissipation>
+        </drake:proximity_properties>
       </collision>
     </link>
     <joint name='j2s7s300_joint_6' type='revolute'>
@@ -493,6 +499,12 @@ Later edited by hand to:
           </ode>
           </friction>
         </surface>
+        <drake:proximity_properties>
+          <drake:compliant_hydroelastic/>
+          <drake:mesh_resolution_hint>0.1</drake:mesh_resolution_hint>
+          <drake:hydroelastic_modulus>5e7</drake:hydroelastic_modulus>
+          <drake:hunt_crossley_dissipation>1.25</drake:hunt_crossley_dissipation>
+        </drake:proximity_properties>
       </collision>
     </link>
 


### PR DESCRIPTION
Modifies `ExampleBase` to add the ability to specify a different model for simulation than for optimization. By default, the same model is used for both simulation and optimization. 

Updates the simulation models for the `jaco` and `dual_jaco` arms to (1) include gravity in the arm models and (2) use hydroelastic contact.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vincekurtz/drake/71)
<!-- Reviewable:end -->
