### PR TITLE
Use consistent parameter initialization style

### DIFF
--- a/traj_opt/examples/yaml_config.h
+++ b/traj_opt/examples/yaml_config.h
@@ -123,7 +123,7 @@ struct TrajOptExampleParams {
   std::string linesearch{"armijo"};
 
   // Optimization method, "linesearch" or "trust_region"
-  std::string method;
+  std::string method{"trust_region"};
 
   // Method of computing gradients, "forward_differences",
   // "central_differences", "central_differences4" or "autodiff"
@@ -144,91 +144,87 @@ struct TrajOptExampleParams {
 
   // Whether to add a proximal operator term to the cost (essentially adds to
   // the diagonal of the Hessian)
-  bool proximal_operator = false;
-  double rho_proximal = 1e-8;
+  bool proximal_operator{false};
+  double rho_proximal{1e-8};
 
   // Flags for playing back the target trajectory, initital guess, and optimal
   // trajectory on the visualizer
-  bool play_optimal_trajectory = true;
-  bool play_initial_guess = false;
-  bool play_target_trajectory = false;
+  bool play_optimal_trajectory{true};
+  bool play_initial_guess{false};
+  bool play_target_trajectory{false};
 
   // Save cost along the linesearch direction to linesearch_data.csv
-  bool linesearch_plot_every_iteration = false;
+  bool linesearch_plot_every_iteration{false};
 
   // Print additional debugging data
-  bool print_debug_data = false;
+  bool print_debug_data{false};
 
   // Save convergence data to solver_stats.csv
-  bool save_solver_stats_csv = true;
+  bool save_solver_stats_csv{true};
 
   // Contact model parameters
-  double F = 1.0;
-  double delta = 0.01;
-  double dissipation_velocity = 0.1;
-  bool force_at_a_distance = false;
-  double smoothing_factor = 0.01;
-  double stiction_velocity = 0.05;
-  double friction_coefficient = 0.0;
+  double F{1.0};
+  double delta{0.01};
+  double dissipation_velocity{0.1};
+  bool force_at_a_distance{true};
+  double smoothing_factor{1.0};
+  double stiction_velocity{0.05};
+  double friction_coefficient{0.5};
 
   // Save data for a 2d contour plot of cost/gradient/Hessian w.r.t. the first
   // two variables to contour_data.csv
-  bool save_contour_data = false;
-  double contour_q1_min = 0;
-  double contour_q1_max = 1;
-  double contour_q2_min = 0;
-  double contour_q2_max = 1;
+  bool save_contour_data{false};
+  double contour_q1_min{0};
+  double contour_q1_max{1};
+  double contour_q2_min{0};
+  double contour_q2_max{1};
 
   // Save data for plotting the cost/gradient/Hessian w.r.t. the first variable
   // to lineplot_data.csv
-  bool save_lineplot_data = false;
-  double lineplot_q_min = 0;
-  double lineplot_q_max = 1;
+  bool save_lineplot_data{false};
+  double lineplot_q_min{0};
+  double lineplot_q_max{1};
 
   // Whether to print iteration data to stdout
-  bool verbose = true;
+  bool verbose{true};
 
   // Whether to normalize quaternion DoFs between iterations
-  bool normalize_quaternions = false;
+  bool normalize_quaternions{false};
 
   // Whether to use an exact (autodiff on the finite diff gradient) Hessian
-  bool exact_hessian = false;
+  bool exact_hessian{false};
 
   // Whether to rescale the Hessian
-  bool scaling = true;
+  bool scaling{true};
 
   // MPC-related parameters
-  bool mpc = false;    // whether to do MPC
-  int mpc_iters = 10;  // fixed number of optimizer iterations
-  double controller_frequency =
-      30;  // target control frequency, should be slow enough to allow for the
-           // optimizer to finish the prescribed number of iterations
-  double sim_time = 10.0;       // Time to simulate for, in seconds
-  double sim_time_step = 1e-3;  // Simulator time step
-  double sim_realtime_rate =
-      1.0;  // Simulator realtime rate. Allows us to imitate a faster controller
-            // by slowing down the simulation.
+  bool mpc{false};                  // whether to do MPC
+  int mpc_iters{1};                 // fixed number of optimizer iterations
+  double controller_frequency{30};  // target control frequency
+  double sim_time{10.0};            // Time to simulate for, in seconds
+  double sim_time_step{1e-3};       // Simulator time step
+  double sim_realtime_rate{1.0};    // Simulator realtime rate
 
   // Gains for the low-level PD+ controller that operates between MPC
   // iterations. Terms related to unactuated DoFs are ignored.
   VectorXd Kp;
   VectorXd Kd;
-  bool feed_forward = true;
+  bool feed_forward{true};
 
   // Method to use when rescaling the Hessian
-  std::string scaling_method = "double_sqrt";
+  std::string scaling_method{"double_sqrt"};
 
   // Whether to enforce strict equality constraints
-  bool equality_constraints = false;
+  bool equality_constraints{true};
 
   // Maximum trust region radius
-  double Delta_max = 1e5;
+  double Delta_max{1e5};
 
   // Initial trust region radius
-  double Delta0 = 1e-1;
+  double Delta0{1e-1};
 
   // Number of cpu threads to use for parallel computation of derivatives
-  int num_threads = 1;
+  int num_threads{1};
 };
 
 }  // namespace examples

--- a/traj_opt/solver_parameters.h
+++ b/traj_opt/solver_parameters.h
@@ -88,17 +88,16 @@ struct SolverParameters {
   SolverParameters() = default;
 
   // Which overall optimization strategy to use - linesearch or trust region
-  // TODO(vincekurtz): better name for this?
-  SolverMethod method = SolverMethod::kTrustRegion;
+  SolverMethod method{SolverMethod::kTrustRegion};
 
   // Which linesearch strategy to use
-  LinesearchMethod linesearch_method = LinesearchMethod::kArmijo;
+  LinesearchMethod linesearch_method{LinesearchMethod::kArmijo};
 
   // Maximum number of Gauss-Newton iterations
-  int max_iterations = 100;
+  int max_iterations{100};
 
   // Maximum number of linesearch iterations
-  int max_linesearch_iterations = 50;
+  int max_linesearch_iterations{50};
 
   GradientsMethod gradients_method{kForwardDifferences};
 
@@ -112,11 +111,11 @@ struct SolverParameters {
   bool normalize_quaternions{false};
 
   // Flag for whether to print out iteration data
-  bool verbose = true;
+  bool verbose{true};
 
   // Flag for whether to print (and compute) additional slow-to-compute
   // debugging info, like the condition number, at each iteration
-  bool print_debug_data = false;
+  bool print_debug_data{false};
 
   // Only for debugging. When `true`, the computation with sparse algebra is
   // checked against a dense LDLT computation. This is an expensive check and
@@ -128,7 +127,7 @@ struct SolverParameters {
   // later plotting). This saves a file called "linesearch_data_[k].csv" for
   // each iteration, where k is the iteration number. This file can then be
   // found somewhere in drake/bazel-out/.
-  bool linesearch_plot_every_iteration = false;
+  bool linesearch_plot_every_iteration{false};
 
   // Flag for whether to add a proximal operator term,
   //
@@ -136,57 +135,57 @@ struct SolverParameters {
   //
   // to the cost, where q_{k-1} are the decision variables at iteration {k-1}
   // and H_{k-1} is the Hessian at iteration k-1.
-  bool proximal_operator = false;
+  bool proximal_operator{false};
 
   // Scale factor for the proximal operator cost
-  double rho_proximal = 1e-8;
+  double rho_proximal{1e-8};
 
   // Contact model parameters
   // TODO(vincekurtz): this is definitely the wrong place to specify the contact
   // model - figure out the right place and put these parameters there
-  double F = 1.0;       // force (in Newtons) at delta meters of penetration
-  double delta = 0.01;  // penetration distance at which we apply F newtons
+  double F{1.0};       // force (in Newtons) at delta meters of penetration
+  double delta{0.01};  // penetration distance at which we apply F newtons
   double dissipation_velocity{0.1};  // Hunt-Crossley velocity, in m/s.
-  double stiction_velocity{1.0e-2};  // Regularization of stiction, in m/s.
-  double friction_coefficient{1.0};  // Coefficient of friction.
+  double stiction_velocity{0.05};    // Regularization of stiction, in m/s.
+  double friction_coefficient{0.5};  // Coefficient of friction.
 
-  bool force_at_a_distance{false};  // whether to allow force at a distance
-  double smoothing_factor{0.01};    // force at a distance smoothing
+  bool force_at_a_distance{true};  // whether to allow force at a distance
+  double smoothing_factor{1.0};    // force at a distance smoothing
 
   // Flags for making a contour plot with the first two decision variables.
-  bool save_contour_data = false;
-  double contour_q1_min = 0.0;
-  double contour_q1_max = 1.0;
-  double contour_q2_min = 0.0;
-  double contour_q2_max = 1.0;
+  bool save_contour_data{false};
+  double contour_q1_min{0.0};
+  double contour_q1_max{1.0};
+  double contour_q2_min{0.0};
+  double contour_q2_max{1.0};
 
   // Flags for making line plots with the first decision variable
-  bool save_lineplot_data = false;
-  double lineplot_q_min = 0.0;
-  double lineplot_q_max = 1.0;
+  bool save_lineplot_data{false};
+  double lineplot_q_min{0.0};
+  double lineplot_q_max{1.0};
 
   // Flag for choosing between the exact Hessian (autodiff, very slow) and a
   // Gauss-Newton approximation
-  bool exact_hessian = false;
+  bool exact_hessian{false};
 
   // Flag for rescaling the Hessian, for better numerical conditioning
-  bool scaling = true;
+  bool scaling{true};
 
   // Method to use for rescaling the Hessian (and thus reshaping the Hessian)
   ScalingMethod scaling_method{ScalingMethod::kDoubleSqrt};
 
   // Parameter for activating hard equality constraints on unactuated DoFs
-  bool equality_constraints = false;
+  bool equality_constraints{true};
 
   // Initial and maximum trust region radius
   // N.B. these have very different units depending on whether scaling is used.
   // These defaults are reasonable when scaling=true: without scaling a smaller
   // trust region radius is more appropriate.
-  double Delta0 = 1e-1;
-  double Delta_max = 1e5;
+  double Delta0{1e-1};
+  double Delta_max{1e5};
 
   // Number of cpu threads for parallel computation of derivatives
-  int num_threads = 1;
+  int num_threads{1};
 };
 
 }  // namespace traj_opt


### PR DESCRIPTION
Parameter initializations now use curly braces, e.g., `int foo{3}` instead of `int foo = 3`.

Also updates a few defaults to reflect our current standard practices.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vincekurtz/drake/76)
<!-- Reviewable:end -->
