### PR TITLE
Add better q_guess checks for the examples

### DIFF
--- a/traj_opt/examples/example_base.cc
+++ b/traj_opt/examples/example_base.cc
@@ -204,6 +204,12 @@ TrajectoryOptimizerSolution<double> TrajOptExample::SolveTrajectoryOptimization(
       opt_prob.q_init, options.q_guess, opt_prob.num_steps + 1);
   NormalizeQuaternions(plant, &q_guess);
 
+  // N.B. This should always be the case, and is checked by the solver. However,
+  // sometimes floating point + normalization stuff makes q_guess != q_init, so
+  // we'll just doubly enforce that here
+  DRAKE_DEMAND((q_guess[0] - opt_prob.q_init).norm() < 1e-8);
+  q_guess[0] = opt_prob.q_init;
+
   // Visualize the target trajectory and initial guess, if requested
   if (options.play_target_trajectory) {
     PlayBackTrajectory(opt_prob.q_nom, options.time_step);


### PR DESCRIPTION
Ensures that floating point issues don't cause very small deviations between `q_guess` and `q_init`. This is checked later in the optimizer, and can lead to annoying and hard-to-diagnose failures without this fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vincekurtz/drake/87)
<!-- Reviewable:end -->
